### PR TITLE
KIN-6589 - add done as an optional termination method

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,12 +295,7 @@ module.exports = {
 		'promise/always-return': 'warn',
 
 		// https://www.npmjs.com/package/eslint-plugin-promise#rule-catch-or-return
-		'promise/catch-or-return': [
-			'warn',
-			{
-				terminationMethod: ['catch', 'done']
-			}
-		],
+		'promise/catch-or-return': 'warn',
 
 		// https://www.npmjs.com/package/eslint-plugin-promise#rule-no-return-wrap
 		'promise/no-return-wrap': 'warn',

--- a/web.js
+++ b/web.js
@@ -10,5 +10,14 @@ module.exports = {
 		mocha: true,
 		mongo: false,
 		node: false
+	},
+	rules: {
+	// Whitelisting done for 'alternative promise chains'.
+		'promise/catch-or-return': [
+			'warn',
+			{
+				terminationMethod: ['catch', 'done']
+			}
+		]
 	}
 };


### PR DESCRIPTION
Code change:
A promise chain can now either end with `catch()` (same as before) or with `done()` (for front end needs).

To test:
- In the Kink-Web `package.json`, point `eslint-config-kink` to `"git+ssh://git@github.com/Kink-Com/eslint-config-kink.git#c613de6",`.
- Run `npm i`.
- Open `public/javascripts/kinklib/shoot.js`. Check that there are no `catch-or-return` linter errors, since the linter is now ok with the Promise chain completing with `done()` instead of `catch()`.