### PR TITLE
KIN-8053 - turn off vue html-indent linting because no tab support!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG.md
 
+## v1.7.3 - 2018.08.24
+- Disabled `vue/html-indent` in `vue.js`
+
 ## v1.7.2 - 2018.07.20
 - Removed nsp from circleci config and package.json
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-kink",
-  "version": "1.7.1",
+  "version": "1.7.3",
   "description": "Kink.com ESLint standards",
   "main": "index.js",
   "dependencies": {

--- a/vue.js
+++ b/vue.js
@@ -14,6 +14,9 @@ module.exports = {
 	},
 	rules: {
 		// Conflict with Node 6 and Vue; remove when we upgrade to Node 8.
-		'node/no-unsupported-features': 0
+		'node/no-unsupported-features': 0,
+		// `html-indent` does not currently support spaces & since we are all
+		// tabs everywhere, let's keep it that way!
+		'vue/html-indent': 0
 	}
 };


### PR DESCRIPTION
# https://cnemedia.atlassian.net/browse/KIN-8053

- Disabled `vue/html-indent` in `vue.js` (aka Shine it on til https://github.com/vuejs/eslint-plugin-vue/pull/428 is merged.)

